### PR TITLE
add catching NoSuchProcess and IOError exceptions

### DIFF
--- a/ppmon
+++ b/ppmon
@@ -17,7 +17,6 @@ __version__ = "0.1"
 __email__ = "Igor.Podoski@ts.fujitsu.com"
 __status__ = "Test/Dev"
 
-
 ###############################################################################
 # Local functions                                                             #
 ###############################################################################
@@ -147,75 +146,77 @@ def get_range(s):
 ###############################################################################
 # fetch data from node
 def remote_mon(mode, track_process, proc_id_pattern):
-  node_stat = {}
+    node_stat = {}
 
-  if psutil.version_info < (2,0):
     for proc in psutil.process_iter():
-      if proc.name in track_process:
+        find_id = proc_id_pattern.search(' '.join(proc.cmdline))
+        if not find_id:
+            continue
+
         try:
-          find_id = proc_id_pattern.search(str(' ').join(proc.cmdline))
-          if find_id:
             key = "{0} {1:>3}".format(proc.name, find_id.group(1))
-          else:
-            continue
         except psutil.NoSuchProcess:
-          continue
+            continue
 
-        if mode == 'm':
-          mem_page_flt = open('/proc/%d/stat' % proc.pid).readline().split()[9:12]
-          node_stat[key] = {
-            'rss'  : proc.get_memory_info().rss,
-            'min_f': mem_page_flt[0],
-            'maj_f': mem_page_flt[2],
-          }
-        elif mode == 'i': 
-          node_stat[key] = {
-            'io_rd': proc.get_io_counters().read_count,
-            'io_rb': proc.get_io_counters().read_bytes,
-            'io_wr': proc.get_io_counters().write_count,
-            'io_wb': proc.get_io_counters().write_bytes,
-          }
-        elif mode == 'c': 
-          node_stat[key] = {
-            'ctx_i': proc.get_num_ctx_switches().involuntary,
-            'ctx_v': proc.get_num_ctx_switches().voluntary,
-            'cpu_usr': proc.get_cpu_times().user,
-            'cpu_sys': proc.get_cpu_times().system,
-          }
-  else:
-    for proc in psutil.process_iter():
-      if proc.name() in track_process:
         try:
-          find_id = proc_id_pattern.search(str(' ').join(proc.cmdline()))
-          if find_id:
-            key = "{0} {1:>3}".format(proc.name(), find_id.group(1))
-          else:
-            continue
-        except psutil.NoSuchProcess:
-          continue
+            if mode == 'm':
+                try:
+                    f = open('/proc/{0}/stat'.format(proc.pid))
+                    stat = f.readline().split()[9:12]
+                except IOError:
+                    continue
 
-        if mode == 'm':
-          mem_page_flt = open('/proc/%d/stat' % proc.pid).readline().split()[9:12]
-          node_stat[key] = {
-            'rss'  : proc.memory_info().rss,
-            'min_f': mem_page_flt[0],
-            'maj_f': mem_page_flt[2],
-          }
-        elif mode == 'i': 
-          node_stat[key] = {
-            'io_rd': proc.io_counters().read_count,
-            'io_rb': proc.io_counters().read_bytes,
-            'io_wr': proc.io_counters().write_count,
-            'io_wb': proc.io_counters().write_bytes,
-          }
-        elif mode == 'c': 
-          node_stat[key] = {
-            'ctx_i': proc.num_ctx_switches().involuntary,
-            'ctx_v': proc.num_ctx_switches().voluntary,
-            'cpu_usr': proc.cpu_times().user,
-            'cpu_sys': proc.cpu_times().system,
-          }
-  return node_stat
+                if psutil.version_info < (2,0):
+                    node_stat[key] = {
+                        'rss': proc.get_memory_info().rss,
+                        'min_f': stat[0],
+                        'maj_f': stat[2],
+                    }
+                else:
+                    node_stat[key] = {
+                        'rss': proc.memory_info().rss,
+                        'min_f': stat[0],
+                        'maj_f': stat[2],
+                    }
+
+            elif mode == 'i':
+                if psutil.version_info < (2,0):
+                    node_stat[key] = {
+                        'io_rd': proc.get_io_counters().read_count,
+                        'io_rb': proc.get_io_counters().read_bytes,
+                        'io_wr': proc.get_io_counters().write_count,
+                        'io_wb': proc.get_io_counters().write_bytes
+                    }
+                else:
+                    node_stat[key] = {
+                        'io_rd': proc.io_counters().read_count,
+                        'io_rb': proc.io_counters().read_bytes,
+                        'io_wr': proc.io_counters().write_count,
+                        'io_wb': proc.io_counters().write_bytes
+                    }
+            elif mode == 'c':
+                if psutil.version_info < (2,0):
+                    node_stat[key] = {
+                        'ctx_i': proc.get_num_ctx_switches().involuntary,
+                        'ctx_v': proc.get_num_ctx_switches().voluntary,
+                        'cpu_usr': proc.get_cpu_times().user,
+                        'cpu_sys': proc.get_cpu_times().system,
+                    }
+                else:
+                    node_stat[key] = {
+                        'ctx_i': proc.num_ctx_switches().involuntary,
+                        'ctx_v': proc.num_ctx_switches().voluntary,
+                        'cpu_usr': proc.cpu_times().user,
+                        'cpu_sys': proc.cpu_times().system,
+                    }
+
+        except psutil.NoSuchProcess:
+            if key in node_stat:
+                del node_stat[key]
+
+            continue
+
+    return node_stat
 
 
 ###############################################################################


### PR DESCRIPTION
When process represented by psutil.Process object is done and then any
member function of that object is called we receive psutil.NoSuchProcess
exception.

An IOError exception can occur when process is done after fetching it by
psutil and before its memory information is obtained from /proc
filesystem.

This commit adds simple support for both cases.
